### PR TITLE
Publish images to Github Container Registry

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,95 +1,51 @@
---- 
+---
+name: Publish Docker images
 
-name: "Publish Docker image"
-
-on: 
-  release: 
-    types: [published]
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
+on:
   push:
     branches:
-      - 'main'
+      - main
+  workflow_dispatch:
 
-jobs: 
+env:
+  IMAGE_REGISTRY_USERNAME: ${{ github.repository_owner }}
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
-  push_to_registry: 
-    name: "Push Docker image to Docker Hub"
+jobs:
+  push_to_registry:
+    name: Build and push Docker images
     runs-on: ubuntu-latest
-    steps: 
-      - 
-        name: "Check out the repo"
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Check out the repo
         uses: actions/checkout@v3
-      - 
-        name: "Log in to Docker Hub"
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with: 
-          password: "${{ secrets.DOCKER_PASSWORD }}"
-          username: "${{ secrets.DOCKER_USERNAME }}"
 
+      - name: Log in to Github Container Registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $IMAGE_REGISTRY -u $IMAGE_REGISTRY_USERNAME --password-stdin
 
-      - 
-        id: meta-common
-        name: "Extract metadata (tags, labels) for Docker"
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with: 
-          images: allanmoso/gitworkshop-common 
-      - 
-        name: "Build and push Docker image"
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with: 
-          context: "."
-          labels: "${{ steps.meta-common.outputs.labels }}"
-          push: true
-          tags: "${{ steps.meta-common.outputs.tags }}"
-          file: "Dockerfile.common"
+      - name: Build and push images
+        run: |
+          # Get the Dockerfile name with no path
+          DOCKERFILES=$(find . -name 'Dockerfile.*' | xargs --max-lines=1 basename)
 
+          echo "
+          Building the following Dockerfiles:
+          $DOCKERFILES
+          "
 
-      - 
-        id: meta-split-commit
-        name: "Extract metadata (tags, labels) for Docker"
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with: 
-          images: allanmoso/gitworkshop-split-commit 
-      - 
-        name: "Build and push Docker image"
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with: 
-          context: "."
-          labels: "${{ steps.meta-split-commit.outputs.labels }}"
-          push: true
-          tags: "${{ steps.meta-split-commit.outputs.tags }}"
-          file: "Dockerfile.split-commit"
+          for DOCKERFILE in $DOCKERFILES; do
 
+            # Make an image name like: gitworkshop-push-conflict
+            IMAGE_NAME=gitworkshop-$(echo $DOCKERFILE | cut -d . -f 2)
 
-      - 
-        id: meta-push-conflict
-        name: "Extract metadata (tags, labels) for Docker"
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with: 
-          images: allanmoso/gitworkshop-push-conflict 
-      - 
-        name: "Build and push Docker image"
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with: 
-          context: "."
-          labels: "${{ steps.meta-push-conflict.outputs.labels }}"
-          push: true
-          tags: "${{ steps.meta-push-conflict.outputs.tags }}"
-          file: "Dockerfile.push-conflict"
+            echo "🛠️ Building and pushing an image made from the Dockerfile: $DOCKERFILE"
+            docker buildx build \
+              --file $DOCKERFILE -t $IMAGE_REGISTRY/$IMAGE_NAME \
+              --platform linux/arm64,linux/amd64 \
+              --push \
+              --tag $FULL_IMAGE_TAG \
+              .
 
-      - 
-        id: meta-merge-conflict
-        name: "Extract metadata (tags, labels) for Docker"
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with: 
-          images: allanmoso/gitworkshop-merge-conflict 
-      - 
-        name: "Build and push Docker image"
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with: 
-          context: "."
-          labels: "${{ steps.meta-merge-conflict.outputs.labels }}"
-          push: true
-          tags: "${{ steps.meta-merge-conflict.outputs.tags }}"
-          file: "Dockerfile.merge-conflict"
+          done

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,10 +42,10 @@ jobs:
 
             echo "🛠️ Building and pushing an image made from the Dockerfile: $DOCKERFILE"
             docker buildx build \
-              --file $DOCKERFILE -t $IMAGE_REGISTRY/$IMAGE_NAME \
+              --file $DOCKERFILE \
               --platform linux/arm64,linux/amd64 \
               --push \
-              --tag $FULL_IMAGE_TAG \
+              --tag $IMAGE_REGISTRY/$IMAGE_NAME \
               .
 
           done

--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -1,14 +1,24 @@
-FROM alpine/git
+FROM alpine:3.16
+
+RUN apk add --no-cache git vim
+
+WORKDIR /git
 
 RUN git config --global init.defaultBranch main
 RUN git config --global user.name Workshop Participant
 RUN git config --global user.email workshop_participant@workshop.e-gineering.com
 RUN git config --global pull.rebase false
 
-RUN mkdir git-workshop.git && cd git-workshop.git && git init --bare && cd ..
-RUN mkdir git-workshop-clone && cd git-workshop-clone && echo '# Git Workshop' > README.md && git init && git add README.md && git commit -m "first commit" && git branch -M main && git remote add origin /git/git-workshop.git && git push -u origin main
+RUN git init --bare git-workshop.git
 
-RUN apk add vim
+RUN git init git-workshop-clone \
+ && cd git-workshop-clone \
+ && echo '# Git Workshop' > README.md \
+ && git add README.md \
+ && git commit -m "first commit" \
+ && git branch -M main \
+ && git remote add origin /git/git-workshop.git \
+ && git push -u origin main
 
 WORKDIR /git/git-workshop-clone
 

--- a/Dockerfile.merge-conflict
+++ b/Dockerfile.merge-conflict
@@ -1,4 +1,4 @@
-FROM allanmoso/gitworkshop-common:main
+FROM ghcr.io/egineering-llc/gitworkshop-common
 
 RUN git checkout main \
     && echo 'Middle line' > conflict.txt \

--- a/Dockerfile.push-conflict
+++ b/Dockerfile.push-conflict
@@ -1,4 +1,4 @@
-FROM allanmoso/gitworkshop-common:main
+FROM ghcr.io/egineering-llc/gitworkshop-common
 
 RUN git checkout -b push-conflict \
     && echo 'Middle line' > conflict.txt \

--- a/Dockerfile.split-commit
+++ b/Dockerfile.split-commit
@@ -1,4 +1,4 @@
-FROM allanmoso/gitworkshop-common:main
+FROM ghcr.io/egineering-llc/gitworkshop-common
 
 RUN git checkout -b split-commit-exercise
 RUN echo 'Middle line' > split.txt && git add split.txt && git commit -m 'Initial state for split commit exercise.'


### PR DESCRIPTION
Summary of changes below, and let me know if I should change anything...

- Publish to Github Container Registry
  - Make the images multi-arch, anticipating a error we could get if people are using a M1 Mac. I think my coworker saw that the images running in docker desktop on are linux/arm64 images. Turns out it was pretty easy to switch to `docker buildx` to build those.
  -  Loop through the Dockerfiles to build them. Right now it's not as resilient to folder change, but I wasn't sure what the final folder structure would be, and it'd be easy to change in the future.
  - Change the Github Actions to run just on a push to main. I'm not sure what the checks will look like, but I imagine those will be in a different actions yaml file.
- Change the common image to a `alpine:3.16` base. 
- Change some of the `git init` commands, since I found you can pass the target folder at the end of the command. Just makes it a bit shorter without losing readability I think. 