### PR TITLE
Make sure the images are built in alphabetical order

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build and push images
         run: |
           # Get the Dockerfile name with no path
-          DOCKERFILES=$(find . -name 'Dockerfile.*' | xargs --max-lines=1 basename)
+          DOCKERFILES=$(find . -name 'Dockerfile.*' | xargs --max-lines=1 basename | sort)
 
           echo "
           Building the following Dockerfiles:


### PR DESCRIPTION
A follow-on from #15, since the other images built before the common image was built for the first time.

Since `common` is first alphabetically, this should work.

If not, I'll probably just push the common image from my local to kick start it.