### PR TITLE
Misc Dockerfile changes

### DIFF
--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -1,25 +1,47 @@
+# syntax=docker/dockerfile:1
+
 FROM alpine:3.16
 
-RUN apk add --no-cache git vim
+RUN <<EOF
 
-WORKDIR /git
+  # Install some packages
+  #   less: installing the GNU less instead of the busybox less, to show colors in the `git diff` output
+  #   git-perl: for interactive git commands to work
+  apk add --no-cache \
+    bash \
+    bash-completion \
+    git \
+    git-perl \
+    less \
+    vim
 
-RUN git config --global init.defaultBranch main
-RUN git config --global user.name Workshop Participant
-RUN git config --global user.email workshop_participant@workshop.e-gineering.com
-RUN git config --global pull.rebase false
+  # Make the command prompt in bash show the working directory instead of `bash-5.1`
+  echo 'PS1="\w $ "' >> ~/.bashrc
 
-RUN git init --bare git-workshop.git
+  # Get our git config set up
+  git config --global init.defaultBranch main
+  git config --global user.name Workshop Participant
+  git config --global user.email workshop_participant@workshop.e-gineering.com
+  git config --global pull.rebase false
 
-RUN git init git-workshop-clone \
- && cd git-workshop-clone \
- && echo '# Git Workshop' > README.md \
- && git add README.md \
- && git commit -m "first commit" \
- && git branch -M main \
- && git remote add origin /git/git-workshop.git \
- && git push -u origin main
+  mkdir /git
+  cd /git
+
+  # Create the git-workshop "remote" repo
+  git init --bare git-workshop.git
+
+  # Prepare the git-workshop-clone repo
+  git init git-workshop-clone
+  cd git-workshop-clone
+  echo '# Git Workshop' > README.md
+  git add README.md
+  git commit -m "first commit"
+  git branch -M main
+  git remote add origin /git/git-workshop.git
+  git push -u origin main
+
+EOF
 
 WORKDIR /git/git-workshop-clone
 
-ENTRYPOINT sh
+ENTRYPOINT bash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You should see a conflict error.
 The goal is to be able to merge the branch successfully by resolving the conflict.
 
 Preferrably you want to end with a file that looks like below:
-```
+```diff
 +First line
 +Line 2
  Middle line
@@ -31,21 +31,21 @@ Preferrably you want to end with a file that looks like below:
 Simulates an issue when two separate git users are committing to the same branch with conflicting changes.
 
 The current local repository has 1 commit that is not yet pushed to the remote repository:
-```
+```diff
 +First line
  Middle line
 +Last line
 ```
 
 However, someone else had pushed changes into the same branch in the remote repository that conflicts with your change:
-```
+```diff
 +Line 1
  Middle line
 +Line 3
 ```
 
 The goal is to push your changes keeping all the changes (modified to make sense):
-```
+```diff
 +First line
 +Line 2
  Middle line
@@ -61,7 +61,7 @@ Simulates having to split a set of unstaged changes into two (or more commits).
 There are uncommitted changes in the `split.txt` file. 
 
 Running `git diff` should look like this:
-```
+```diff
 /git/git-workshop-clone # git diff
 diff --git a/split.txt b/split.txt
 index 3ea4248..3988358 100644


### PR DESCRIPTION
I started down a rabbit hole while trying to get interactive commands like `git add -p` to work. Ended up finding some neat new buildkit features, and also got the image layers for the common image down to 3 layers.

- Change to the buildkit syntax ([link](https://docs.docker.com/engine/reference/builder/#syntax))
  - And move things into one `RUN` command using the new heredoc syntax ([link](https://github.com/moby/moby/issues
/16058#issuecomment-881901519))
- Switch to bash + bash-completion to be able to tab-complete git commands
- Install git-perl to be able to run interactive commands like `git add -p` ([link](https://stackoverflow.com/a/57632778/7733616))
- Install GNU `less` to get colors to show nicely in the `git diff` output (the busybox less wasn't showing them)

Lemme know what you think :slightly_smiling_face: 