### PR TITLE
Add new scenario: squash-commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN <<EOF
 
   # Install some packages
   #   less: installing the GNU less instead of the busybox less, to show colors in the `git diff` output
-  #   git-perl: for interactive git commands to work
+  #   git-perl: getting the interactive git commands to work
+  #   mandoc & git-doc: installing the man pages for git
   apk add --no-cache \
     bash \
     bash-completion \

--- a/squash-commits/Dockerfile
+++ b/squash-commits/Dockerfile
@@ -47,4 +47,7 @@ RUN <<EOF
   # Push up our branch, so we will need to force-push to get the remote updated after squashing
   git push -u origin HEAD
 
+  # Save 300 MB or so
+  rm -rf node_modules
+
 EOF

--- a/squash-commits/Dockerfile
+++ b/squash-commits/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+
+FROM ghcr.io/egineering-llc/gitworkshop-common
+
+RUN <<EOF
+
+  apk add --no-cache nodejs npm
+
+  # Remove the existing readme to keep create-next-app from complaining
+  rm README.md
+
+  npx create-next-app@13.0.0 .
+  git add -A
+  git commit -m 'Install Next using create-next-app'
+  git push
+
+  git checkout -b feature/start-setting-up-repo
+
+  # Add a package to just the package.json
+  npm install --save-dev eslint-config-airbnb
+  git checkout package-lock.json
+  git commit -am 'Install eslint-config-airbnb'
+
+  # Update the package lock
+  npm i
+  git commit -am 'oops forgot to update the package-lock.json'
+
+  # Install the needed peer dependencies
+  npx install-peerdeps --dev eslint-config-airbnb
+  git commit -am 'forgot the peer dependencies'
+
+  # Set up the eslintrc file
+  node -e 'console.log(JSON.stringify({"extends": ["airbnb"]}, null, 2))' > .eslintrc.json
+  git add -A
+  git commit -m 'and set up the eslintrc file'
+
+  # Add the goodbye page, misspelled
+  cp pages/api/hello.js pages/api/goodbyee.js
+  git add -A
+  git commit -am 'Add the goodbye endpoint'
+
+  # And now fix the spelling
+  mv pages/api/goodbyee.js pages/api/goodbye.js
+  git add -A
+  git commit -m 'Fix filename spelling'
+
+  # Push up our branch, so we will need to force-push to get the remote updated after squashing
+  git push -u origin HEAD
+
+EOF

--- a/squash-commits/README.md
+++ b/squash-commits/README.md
@@ -1,0 +1,28 @@
+# Squash Commits
+
+## Start the scenario
+
+```
+docker run -it ghcr.io/egineering-llc/gitworkshop-squash-commits
+```
+
+## Description
+
+Simulates having to squash several commits together.
+
+So far, you've added these 4 commits while setting up a new package called `eslint-config-airbnb`:
+  - `Install eslint-config-airbnb`
+  - `oops forgot to update the package-lock.json`
+  - `forgot the peer dependencies`
+  - `and set up the eslintrc file`
+
+And then you've started working on a `goodbye` endpoint, but accidentally misspelled it in the first commit, so you made a second one to fix that:
+  - `Add the goodbye endpoint`
+  - `Fix filename spelling`
+
+You've pushed up your local `feature/start-setting-up-repo` branch to the remote, and you're just about ready to make a pull request, but you'd like to squash the commits together, to make it easier on your reviewer to review the changes.
+
+Your goal is to:
+  - Squash the first 4 commits into 1 commit named: `Install eslint-config-airbnb`
+  - Squash the last 2 commit into 1 commit named: `Add the goodbye endpoint`
+  - And then push the new commits up to your remote branch.

--- a/squash-commits/SOLUTION.md
+++ b/squash-commits/SOLUTION.md
@@ -1,0 +1,58 @@
+# Squash Commits (solution)
+
+See a history of your commits with:
+
+```
+git log
+```
+
+You want to squash everything in your branch, so scroll down in the `git log` output until you see the `main` branch.
+
+Start an interactive rebase. We're not changing the base of our branch (it'll remain branched off the same commit that's on the `main` branch), but we want to open up the interactive mode it has to start squashing commits together. 
+
+```
+git rebase -i main
+```
+
+In this case, `main` could've been `origin/main` or the commit hash, but either one will do since they refer to the same commit here. That's not always the case though, so you'll normally want to double-check the `git log` output.
+
+In the interactive rebase, you'll see git has opened an editor, with a list of your commits in oldest-to-newest order, with the special command `pick` next to each commit. If you were to save and quit the editor right now, git would start at the top of the list, and pick each one (using it just as it is) until it gets to the end of the list.
+
+You'll see a list of possible commands or actions that git can take on each commit. The most common ones would probably be:
+  - `pick`: use the commit as it is
+  - `squash`: combine the changes into the previous commit
+  - `reword`: edit the commit message of a commit
+  - `drop`: delete a commit
+
+So you'll want to keep the oldest commit as `pick`, but change the newer commits below it from `pick` to `squash`. You can do multiple at once, so try changing the 3 below the `Install eslint-config-airbnb` commit to `squash`.
+
+Then leave the `Add the goodbye endpoint` commit below that as `pick`, and change the final commit to `squash`.
+
+The final result should look like this (with different commit hashes):
+
+```
+pick 6116bba Install eslint-config-airbnb
+squash 01639cc oops forgot to update the package-lock.json
+squash 32f8981 forgot the peer dependencies
+squash caed21e and set up the eslintrc file
+pick 4799d27 Add the goodbye endpoint
+squash 079a6ea Fix filename spelling
+```
+
+Save and quit your editor, and a new editor will open where you can edit the commit message for your first squashed commit. You'll probably want to edit it to be just the `Install eslint-config-airbnb` message. Save and quit again, and another editor will open with the same thing for the second squashed commit. The message `Add the goodbye endpoint` probably makes sense for this one too, and you can delete the rest of the commit message.
+
+Check `git log` again to make sure you have just two commits on top of `main`. Feel free to re-run `git rebase -i main` to make more changes if needed.
+
+Now push up your changes to the remote:
+
+```
+git push
+```
+
+You'll find that your push is rejected because you rewrote the commit history on your local branch, and git doesn't know how to update the remote branch anymore. Since you're working on a feature branch that only you are working on, it's appropriate to force-push your branch up:
+
+```
+git push -f
+```
+
+And you're done!


### PR DESCRIPTION
Tried making a scenario to squash commits. Also I'm seeing if I can start with a create-next-app as a starting point, and it seemed to work well.

I'm leaving node and npm installed (and not doing a multi-stage build), because I'm thinking someone might get curious and run `npm i` or something. I imagine removing those would free up some space though (image is currently 289 MB).

I did remove node_modules though, which freed up quite a bit of space (about ~300 MB).

You can try the built image from my fork if you'd like:
```
docker run -it ghcr.io/dbirks/gitworkshop-squash-commits
```

Closes #8